### PR TITLE
mostly whitespace changes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,13 @@
-<head>
+	<head>
 		 <meta charset="utf-8">
-  		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" type = "text/css"/>
-    		<link rel="stylesheet" type="text/css" media="screen,projection" href="{{ "/assets/main.css" | relative_url }}">
+		<link rel="stylesheet" type="text/css" media="screen,projection" href="{{ "/assets/main.css" | relative_url }}">
 		<script type="text/javascript" src="javascripts/script.js"></script>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 		<script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 		<link href="https://fonts.googleapis.com/css?family=Oswald" rel="stylesheet">
-		{% seo %}
-</head>
+
+{% seo %}
+
+	</head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,8 @@
     {% assign default_paths = site.pages | map: "path" %}
     {% assign page_paths = site.header_pages | default: default_paths %}
 
-<nav class="navbar navbar-default navbar-fixed-top">
-	<div class="container-fluid">
+	 <nav class="navbar navbar-default navbar-fixed-top">
+	  <div class="container-fluid">
 	    <div class="navbar-header">
 	      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#myNavbar">
 	        <span class="icon-bar"></span>
@@ -14,7 +14,7 @@
 	    <div class="collapse navbar-collapse" id="myNavbar">
 	      <ul class="nav navbar-nav navbar-right">
 	      <!--	<li><a href="{{ "/visit" | relative_url}}">VISIT</a></li>-->
-	      	<li><a href="{{ "/about" | relative_url}}">ABOUT</a></li>
+	        <li><a href="{{ "/about" | relative_url}}">ABOUT</a></li>
 	        <li><a href="{{ "/connect" | relative_url}}">CONNECT</a></li>
 	        <li><a href="{{ "/gp" | relative_url}}">GOSPEL PROJECT</a></li>
 	        <li><a href="https://goo.gl/gciC9i">GIVE</a></li>
@@ -31,5 +31,5 @@
 	        <li><a href="#">GOSPEL PROJECT</a></li> -->
 	      </ul>
 	    </div>
-	</div>
-</nav>
+	  </div>
+	 </nav>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -1,7 +1,8 @@
+<html>
 {% include head.html %}
-<body>
+	<body>
 {% include header.html %}
-  <div class="container-fluid" id="home">
+	  <div class="container-fluid" id="home">
 		<div class="row">
 			<div class="bg-about">
 				<div class="cover-text-bg">
@@ -85,5 +86,6 @@
 				</div>
 			</div>
 		</div>
-	</div>
-</body>
+	  </div>
+	</body>
+</html>

--- a/_layouts/connect.html
+++ b/_layouts/connect.html
@@ -1,7 +1,8 @@
+<html>
 {% include head.html %}
-<body>
+	<body>
 {% include header.html %}
-  <div class="container-fluid" id="home">
+	  <div class="container-fluid" id="home">
 		<div class="row">
 			<div class="bg-connect">
 				<div class="cover-text-bg">
@@ -24,5 +25,6 @@
 				<div class='section-text-block'>List of growth group locations here and times they meet</div>-->
 			</div>
 		</div>
-	</div>
-</body>
+	  </div>
+	</body>
+</html>

--- a/_layouts/gp.html
+++ b/_layouts/gp.html
@@ -1,7 +1,8 @@
+<html>
 {% include head.html %}
-<body>
+	<body>
 {% include header.html %}
-  <div class="container-fluid" id="home">
+	  <div class="container-fluid" id="home">
 		<div class="row">
 			<div class="bg-gp">
 				<div class="cover-text-bg">
@@ -34,5 +35,6 @@
 				<div class='section-text-block'>For brochures and application materials, please email Matthew Beasley at matthewhenrybeasley@gmail.com or use our online application <a href="http://christcommunityok.com/apply">here</a>.</div>
 			</div>
 		</div>
-	</div>
-</body>
+	  </div>
+	</body>
+</html>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,3 +1,4 @@
+<html>
 {% include head.html %}
 	<body>
 {% include header.html %}
@@ -34,8 +35,10 @@
 					<div class='section-text-block'>
 						<p>Throw some Q&A in here.</p>
 					</div>-->
+				</div>
 			</div>
 
 		</div>
 
 	</body>
+</html>

--- a/_layouts/visit.html
+++ b/_layouts/visit.html
@@ -1,7 +1,8 @@
+<html>
 {% include head.html %}
-<body>
+	<body>
 {% include header.html %}
-  <div class="container-fluid" id="home">
+	  <div class="container-fluid" id="home">
 		<div class="row">
 			<div class="bg-visit">
 				<div class="cover-text-bg">
@@ -30,6 +31,8 @@
 				<div class='section-text-block'>
 					<p>Throw some Q&A in here.</p>
 				</div>
+			</div>
 		</div>
-	</div>
-</body>
+	  </div>
+	</body>
+</html>


### PR DESCRIPTION
Changes:
- wrapped layout templates with top-level `<HTML></HTML>` tag
- closed some unclosed `<DIV></DIV>` tags
- made the whitespace a little more consistent

Rationale:
I wrapped the layout templates in that outer `<HTML></HTML>` tag because I think HTML files should be as close to valid XHTML5 as possible, and XHTML is an XML format, and an XML document expects to have a single top-level element.
I closed the un-closed `<DIV></DIV>` tags because the lack of closing tags appeared to be accidental.
I indented the beginnings of things with tabs to the point that it wasn't a major change to do so.  Beyond that point, I indented with fewer than four spaces.  This prevented me from having to re-indent the entire file, which would look like a rewrite.
I put all of these things into one commit because they were all pretty minor, unobjectionable changes.  Initially, I did them as separate commits in another branch, but that branch isn't in a state that is acceptable for merging, so I squashed those changes rather than reproducing each commit in this branch.

The work done here was easy enough that I won't mind redoing it if anyone has a problem with how I did it and wants me to only do part of it.
