### PR TITLE
remove a stray comment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Hope Community Church
 author: hope-community
 email: hopechurchnorman@gmail.com
-description: > # this means to ignore newlines until "baseurl:"
+description: >
   A website for Hope Community Church in Norman, OK
 github_username:  hopechurchnorman
 plugins:


### PR DESCRIPTION
There was a comment in the configuration file that may have been accurate at one time in the past but no longer is, so I've removed it.