### PR TITLE
moved common outer container into layout

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -2,6 +2,8 @@
 {% include head.html %}
 	<body>
 {% include header.html %}
+		<div class="container-fluid" id="home">
 {{ content }}
+		</div>
 	</body>
 </html>

--- a/about.html
+++ b/about.html
@@ -3,7 +3,6 @@ layout: index
 title: ABOUT
 permalink: /about/
 ---
-		<div class="container-fluid" id="home">
 		  <div class="row">
 			<div class="bg-about">
 				<div class="cover-text-bg">
@@ -90,4 +89,3 @@ permalink: /about/
 				</div>
 			</div>
 		  </div>
-		</div>

--- a/connect.html
+++ b/connect.html
@@ -3,7 +3,6 @@ layout: index
 title: CONNECT
 permalink: /connect/
 ---
-		<div class="container-fluid" id="home">
 		  <div class="row">
 			<div class="bg-connect">
 				<div class="cover-text-bg">
@@ -26,4 +25,3 @@ permalink: /connect/
 				<div class='section-text-block'>List of growth group locations here and times they meet</div>-->
 			</div>
 		  </div>
-		</div>

--- a/gp.html
+++ b/gp.html
@@ -3,7 +3,6 @@ layout: index
 title: GOSPEL PROJECT
 permalink: /gp/
 ---
-		<div class="container-fluid" id="home">
 		  <div class="row">
 			<div class="bg-gp">
 				<div class="cover-text-bg">
@@ -36,4 +35,3 @@ permalink: /gp/
 				<div class='section-text-block'>For brochures and application materials, please email Matthew Beasley at matthewhenrybeasley@gmail.com or use our online application <a href="http://christcommunityok.com/apply">here</a>.</div>
 			</div>
 		  </div>
-		</div>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 layout: index
 permalink: /
 ---
-		<div class="container-fluid" id="home">
 			<div class="row">
 				<div class="bg-1">
 					<div class='cover-text-bg'>
@@ -38,4 +37,3 @@ permalink: /
 				</div>
 			</div>
 
-		</div>

--- a/visit.html
+++ b/visit.html
@@ -3,7 +3,6 @@ layout: index
 title: VISIT
 permalink: /secretvisitpage/
 ---
-		<div class="container-fluid" id="home">
 		  <div class="row">
 			<div class="bg-visit">
 				<div class="cover-text-bg">
@@ -34,4 +33,3 @@ permalink: /secretvisitpage/
 				</div>
 			</div>
 		  </div>
-		</div>


### PR DESCRIPTION
All of the .html files at the top level had the same markup containing their contents, so I decided to consider that outer element to be part of the layout that they share.